### PR TITLE
Enhanced Parsing of Excel Rows in buildDataTable Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ fabric.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/goland,go
 .idea
+**/test-results

--- a/cmd/xlsx-tools/parse-xml/parseToXml.go
+++ b/cmd/xlsx-tools/parse-xml/parseToXml.go
@@ -93,20 +93,6 @@ func main() {
 			processingErr = ErrMsg{Err: writeErr, Code: ErrStdout}
 		}
 	}
-	// // write output to xml file
-	// xmlFile, xmlFileErr := os.Create("output.xml")
-	// if xmlFileErr != nil {
-	//     processingErr = ErrMsg{Err: xmlFileErr, Code: ErrWriteFile}
-	// }
-	// defer func() {
-	//     if err := xmlFile.Close(); err != nil {
-	//         processingErr = ErrMsg{Err: err, Code: ErrWriteFile}
-	//     }
-	// }()
-	// _, writeErr := xmlFile.Write(output)
-	// if writeErr != nil {
-	//     processingErr = ErrMsg{Err: writeErr, Code: ErrWriteFile}
-	// }
 }
 
 // CheckExtension checks if the given file path has the specified extension.
@@ -192,6 +178,10 @@ func buildDataTable(rows *excelize.Rows) DataTable {
 				cleanHeader(&headerRow[headerIndex])
 			}
 		} else {
+			// Dirty workaround because `(*rows).Columns()` doesn't do what it says it does.
+			for len(columns) < len(headerRow) {
+				columns = append(columns, "")
+			}
 			var dataRow DataRow
 			for columnIndex := range columns {
 				columnName := headerRow[columnIndex]

--- a/cmd/xlsx-tools/parse-xml/parseToXml_test.go
+++ b/cmd/xlsx-tools/parse-xml/parseToXml_test.go
@@ -1,57 +1,176 @@
 package main
 
 import (
-	"encoding/xml"
-	"reflect"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/xuri/excelize/v2"
 )
 
-func TestBuildDataTable(t *testing.T) {
+func createTestXlsx(fileName string, blankCols, blankRows bool) (filePath string, err error) {
+	if suffix := filepath.Ext(fileName); suffix != ".xlsx" {
+		fileName = strings.TrimSuffix(fileName, suffix) + ".xlsx"
+	}
+	var sheet int
+	// Create a simple test xlsx file.
+	excelFile := excelize.NewFile()
+
+	// Create a test sheet.
+	sheet, err = createTestSheet(excelFile, blankCols, blankRows)
+	if err != nil {
+		return
+	}
+	excelFile.SetActiveSheet(sheet)
+
+	// Save the file.
+	dir, _ := os.Getwd()
+	filePath = filepath.Join(dir, fileName)
+	if err = excelFile.SaveAs(filePath); err != nil {
+		return
+	}
+	return
+}
+
+func createTestSheet(file *excelize.File, blankCols, blankRows bool) (sheet int, err error) {
+	sheet, err = file.NewSheet("TestSheet")
+	if err != nil {
+		return
+	}
+	file.SetActiveSheet(sheet)
+	for colIdx := 1; colIdx <= 10; colIdx++ {
+		for rowIdx := 1; rowIdx <= 10; rowIdx++ {
+			if rowIdx == 1 {
+				cellName, _ := excelize.CoordinatesToCellName(colIdx, rowIdx)
+				if err = file.SetCellValue("TestSheet", cellName, "Column"+cellName); err != nil {
+					return
+				}
+			} else {
+				cellName, _ := excelize.CoordinatesToCellName(colIdx, rowIdx)
+				if err = file.SetCellValue("TestSheet", cellName, colIdx*rowIdx); err != nil {
+					return
+				}
+			}
+		}
+	}
+	if blankCols {
+		for _, colIdx := range []int{2, 3, 4, 10} {
+			for rowIdx := 2; rowIdx <= 10; rowIdx++ {
+				cellName, _ := excelize.CoordinatesToCellName(colIdx, rowIdx)
+				if err = file.SetCellValue("TestSheet", cellName, ""); err != nil {
+					return
+				}
+			}
+		}
+	}
+	if blankRows {
+		for colIdx := 1; colIdx <= 10; colIdx++ {
+			for rowIdx := 5; rowIdx <= 7; rowIdx++ {
+				cellName, _ := excelize.CoordinatesToCellName(colIdx, rowIdx)
+				if err = file.SetCellValue("TestSheet", cellName, ""); err != nil {
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+func createOutputXmlFile(fileName string, xmlData []byte) (string, error) {
+	if suffix := filepath.Ext(fileName); suffix != ".xml" {
+		fileName = strings.TrimSuffix(fileName, suffix) + ".xml"
+	}
+	dir, _ := os.Getwd()
+	filePath := filepath.Join(dir, "test-results", fileName)
+
+	// write output to xml file
+	xmlFile, xmlFileErr := os.Create(filePath)
+	if xmlFileErr != nil {
+		return "", xmlFileErr
+	}
+	defer func() {
+		if err := xmlFile.Close(); err != nil {
+			xmlFileErr = err
+		}
+	}()
+	_, writeErr := xmlFile.Write(xmlData)
+	if writeErr != nil {
+		return "", writeErr
+	}
+	return filePath, nil
+}
+
+func TestParseXlsxFile(t *testing.T) {
+	// Define test files.
+	type testFile struct {
+		name      string
+		blankCols bool
+		blankRows bool
+	}
+	testFiles := []testFile{
+		{"TestFile.xlsx", false, false},
+		{"TestFileBlankRows", false, true},
+		{"TestFileBlankCols.xls", true, false},
+		{"TestFileBlankRowsAndCols.xls", true, true},
+	}
+	// Define test cases.
 	tests := []struct {
-		name string
-		rows [][]string
-		want DataTable
+		name        string
+		filePath    string
+		targetSheet string
+		wantErr     bool
 	}{
 		{
-			name: "empty rows",
-			rows: nil,
-			want: DataTable{},
+			name:        "Valid File & Sheet",
+			targetSheet: "TestSheet",
+			wantErr:     false,
 		},
 		{
-			name: "non-empty row",
-			rows: [][]string{
-				{"column1", "column2", "column3", "column4"},
-				{"row1Value1", "row1Value2", "", ""},
-				{"row2Value1", "row2Value2", "row2Value2", ""},
-			},
-			want: DataTable{
-				Rows: []DataRow{
-					{
-						Columns: []DataColumn{
-							{XMLName: xml.Name{Local: "column1"}, Value: "row1Value1"},
-							{XMLName: xml.Name{Local: "column2"}, Value: "row1Value2"},
-							{XMLName: xml.Name{Local: "column3"}, Value: ""},
-							{XMLName: xml.Name{Local: "column4"}, Value: ""},
-						},
-					},
-					{
-						Columns: []DataColumn{
-							{XMLName: xml.Name{Local: "column1"}, Value: "row2Value1"},
-							{XMLName: xml.Name{Local: "column2"}, Value: "row2Value2"},
-							{XMLName: xml.Name{Local: "column3"}, Value: "row2Value2"},
-							{XMLName: xml.Name{Local: "column4"}, Value: ""},
-						},
-					},
-				},
-			},
+			name:        "Invalid File",
+			filePath:    "InvalidPath",
+			targetSheet: "TestSheet",
+			wantErr:     true,
+		},
+		{
+			name:        "Invalid Sheet",
+			targetSheet: "InvalidSheet",
+			wantErr:     true,
 		},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := buildDataTable(&tt.rows); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("buildDataTable() = %v, want %v", got, tt.want)
+	// Now start with the testing.
+	for fileNum, file := range testFiles {
+		// Create test files - also cheekily testing the logic in createTestXlsx.
+		filePath, err := createTestXlsx(file.name, file.blankCols, file.blankRows)
+		if err != nil {
+			t.Errorf("Error creating test file: %v", err)
+		}
+		t.Logf("Test file %d: %s", fileNum, filePath)
+		for _, tt := range tests {
+			if len(tt.filePath) < 1 {
+				tt.filePath = filePath
 			}
-		})
+			// Clean up the test file when done.
+			t.Run(tt.name, func(t *testing.T) {
+				output, err := parseXlsxFile(tt.filePath, tt.targetSheet)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("parseXlsxFile() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				if !tt.wantErr {
+					// Check if the output is not empty.
+					if len(output) < 1 {
+						t.Errorf("parseXlsxFile() output is empty")
+					}
+					outputPath, err := createOutputXmlFile(file.name, output)
+					if err != nil {
+						t.Errorf("Error creating output file: %v", err)
+					}
+					t.Logf("Output file: %s", outputPath)
+				}
+			})
+		}
+		if err = os.Remove(filePath); err != nil {
+			t.Errorf("Error removing test file: %v", err)
+		}
 	}
 }

--- a/cmd/xlsx-tools/parse-xml/parseToXml_test.go
+++ b/cmd/xlsx-tools/parse-xml/parseToXml_test.go
@@ -20,9 +20,9 @@ func TestBuildDataTable(t *testing.T) {
 		{
 			name: "non-empty row",
 			rows: [][]string{
-				{"column1", "column2"},
-				{"row1Value1", "row1Value2"},
-				{"row2Value1", "row2Value2"},
+				{"column1", "column2", "column3", "column4"},
+				{"row1Value1", "row1Value2", "", ""},
+				{"row2Value1", "row2Value2", "row2Value2", ""},
 			},
 			want: DataTable{
 				Rows: []DataRow{
@@ -30,12 +30,16 @@ func TestBuildDataTable(t *testing.T) {
 						Columns: []DataColumn{
 							{XMLName: xml.Name{Local: "column1"}, Value: "row1Value1"},
 							{XMLName: xml.Name{Local: "column2"}, Value: "row1Value2"},
+							{XMLName: xml.Name{Local: "column3"}, Value: ""},
+							{XMLName: xml.Name{Local: "column4"}, Value: ""},
 						},
 					},
 					{
 						Columns: []DataColumn{
 							{XMLName: xml.Name{Local: "column1"}, Value: "row2Value1"},
 							{XMLName: xml.Name{Local: "column2"}, Value: "row2Value2"},
+							{XMLName: xml.Name{Local: "column3"}, Value: "row2Value2"},
+							{XMLName: xml.Name{Local: "column4"}, Value: ""},
 						},
 					},
 				},

--- a/pkg/helpers/manipulations.go
+++ b/pkg/helpers/manipulations.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 )
 
 // RenameDuplicates takes an input slice of strings and renames any duplicate headers
@@ -83,4 +84,42 @@ func FixXMLTags(tag string) string {
 	}
 	cleanTag = strings.ReplaceAll(cleanTag, " ", "_x0020_")
 	return cleanTag
+}
+
+// ConvertToISO8601 converts a given string value representing a date or time to ISO-8601 format.
+// It supports various date and time formats such as "MM-DD-YY", "MM-DD-YY HH:mm:ss", "1/02/06", etc.
+// The function iterates through the array of supported formats and attempts to parse the value using each format.
+// If a format successfully parses the value, it returns the parsed date in ISO-8601 format using time.DateTime layout.
+// If none of the formats can parse the value, it returns the original value.
+//
+// Example usage:
+//
+//	input := "12-25-20 12:34:56"
+//	result := convertToISO8601(input)
+//	fmt.Println(result)
+//	// Output: "2020-12-25T12:34:56"
+//
+//	input := "invalid date"
+//	result := convertToISO8601(input)
+//	fmt.Println(result)
+//	// Output: "invalid date"
+func ConvertToISO8601(value string) string {
+	formats := [9]string{
+		"01-02-06",
+		"01-02-06 15:04",
+		"01-02-06 15:04:05",
+		"1/02/06",
+		"1/02/06 15:04",
+		"1/02/06 15:04:05",
+		"01/02/06",
+		"01/02/06 15:04",
+		"01/02/06 15:04:05",
+	}
+	for _, format := range formats {
+		parsedDate, parseErr := time.Parse(format, value)
+		if parseErr == nil {
+			return parsedDate.Format(time.DateTime)
+		}
+	}
+	return value
 }


### PR DESCRIPTION
This Pull Request contains changes that add robust handling for Excel rows processing in the `buildDataTable` function. The modifications ensure that even if `rows.Columns()` from the Excelize library behaves inconsistently for some files, our function will still continue to process empty tail cells properly.

The changes include:
- Adding a length comparison between `rows.Columns()` and the header row.
- Filling in any missing tail cells in a row with empty strings.

These changes have been tested on a variety of Excel files and have shown to improve the consistency of data output.

This Fixes #1